### PR TITLE
Change contact info, and package name.

### DIFF
--- a/moz_measure_noise/__init__.py
+++ b/moz_measure_noise/__init__.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 

--- a/moz_measure_noise/analysis.py
+++ b/moz_measure_noise/analysis.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 
@@ -20,10 +20,10 @@ from jx_bigquery import bigquery
 from jx_bigquery.expressions import BQLang
 from jx_bigquery.sql import quote_column, quote_value, sql_iso
 from jx_python import jx
-from measure_noise import deviance, step_detector
-from measure_noise.extract_perf import get_signature, get_dataum
-from measure_noise.step_detector import find_segments, MAX_POINTS, MIN_POINTS
-from measure_noise.utils import assign_colors, histogram
+from moz_measure_noise import deviance, step_detector
+from moz_measure_noise.extract_perf import get_signature, get_dataum
+from moz_measure_noise.step_detector import find_segments, MAX_POINTS, MIN_POINTS
+from moz_measure_noise.utils import assign_colors, histogram
 from mo_collections import left
 from mo_dots import Data, coalesce, unwrap, to_data, listwrap
 from mo_files import File

--- a/moz_measure_noise/analysis_etl.py
+++ b/moz_measure_noise/analysis_etl.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import division
 from __future__ import unicode_literals
@@ -12,9 +12,9 @@ from __future__ import unicode_literals
 import numpy as np
 
 from jx_python import jx
-from measure_noise import deviance
-from measure_noise.extract_perf import get_signature, get_dataum
-from measure_noise.step_detector import find_segments
+from moz_measure_noise import deviance
+from moz_measure_noise.extract_perf import get_signature, get_dataum
+from moz_measure_noise.step_detector import find_segments
 from mo_dots import Data, unwrap
 from mo_json import NUMBER, python_type_to_json_type, scrub
 from mo_logs import Log

--- a/moz_measure_noise/extract_perf.py
+++ b/moz_measure_noise/extract_perf.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 

--- a/moz_measure_noise/step_detector.py
+++ b/moz_measure_noise/step_detector.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 
@@ -13,7 +13,7 @@ import numpy as np
 from numpy.lib.stride_tricks import as_strided
 from scipy.stats import stats, rankdata
 
-from measure_noise.utils import plot
+from moz_measure_noise.utils import plot
 from mo_dots import Data, coalesce
 from mo_logs import Except
 

--- a/moz_measure_noise/utils.py
+++ b/moz_measure_noise/utils.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 

--- a/resources/get_data_from_perfherder.py
+++ b/resources/get_data_from_perfherder.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,15 @@ from setuptools import setup
 setup(
     description=str(u'Measure deviant noise'),
     license=str(u'MPL 2.0'),
-    author=str(u'Kyle Lahnakoski'),
-    author_email=str(u'kyle@lahnakoski.com'),
+    author=str(u'Mozilla Perftest'),
+    author_email=str(u'perftest@mozilla.com'),
     long_description_content_type=str(u'text/markdown'),
     include_package_data=True,
     classifiers=["Development Status :: 4 - Beta","Topic :: Software Development :: Libraries","Topic :: Software Development :: Libraries :: Python Modules","License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"],
-    install_requires=["numpy","scipy"],
-    version=str(u'2.53.19239'),
+    install_requires=["numpy>=1.23.1","scipy"],
+    version=str(u'2.59.0.1'),
     url=str(u'https://github.com/mozilla/measure-noise'),
-    packages=["measure_noise"],
+    packages=["moz_measure_noise"],
     long_description=str(u"# measure-noise\nMeasure how our data deviates from normal distribution\n\n\n|Branch      |Status   | Coverage |\n|------------|---------|----------|\n|master      | [![Build Status](https://travis-ci.org/mozilla/measure-noise.svg?branch=master)](https://travis-ci.org/mozilla/measure-noise) | |\n|dev         | [![Build Status](https://travis-ci.org/mozilla/measure-noise.svg?branch=dev)](https://travis-ci.org/mozilla/measure-noise)    | [![Coverage Status](https://coveralls.io/repos/github/mozilla/measure-noise/badge.svg)](https://coveralls.io/github/mozilla/measure-noise) |\n\n\n## Install\n\n    pip install measure-noise\n\n## Usage\n\nThe `deviance()` method will return a `(description, score)` pair describing how the samples deviate from a normal distribution, and by how much.  This is intended to screen samples for use in the t-test, and other statistics, that assume a normal distribution.\n\n* `SKEWED` - samples are heavily to one side of the mean\n* `OUTLIERS` - there are more outliers than would be expected from normal distribution\n* `MODAL` - few samples are near the mean (probably bimodal)\n* `OK` - no egregious deviation from normal\n* `N/A` - not enough data to make a conclusion (aka `OK`)\n\n#### Example\n\n    from measure_noise import deviance\n\n\t>>> desc, score = deviance([1,2,3,4,5,6,7,8])\n    >>> desc\n    'OK'\n\n## Development\n\n    git clone https://github.com/mozilla/measure-noise.git\n    cd measure-noise\n    pip install -r requirements.txt\n    pip install or tests/requirements.txt\n    python -m unittest discover tests \n\n## Windows\n\nYou must download the `scipy` and `numpy` binary packages. \n"),
-    name=str(u'measure-noise')
+    name=str(u'moz-measure-noise')
 )

--- a/setuptools.json
+++ b/setuptools.json
@@ -1,16 +1,16 @@
 {
-    "author": "Kyle Lahnakoski",
-    "author_email": "kyle@lahnakoski.com",
+    "author": "Mozilla Perftest",
+    "author_email": "perftest@mozilla.com",
     "classifiers": [
         "Development Status :: 4 - Beta",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"
     ],
-    "python_requires": ">=3.7",
+    "python_requires": ">=3.8",
     "description": "Measure deviant noise",
     "include_package_data": true,
-    "install_requires": ["numpy", "scipy"],
+    "install_requires": ["numpy>=1.23.1", "scipy"],
     "license": "MPL 2.0",
     "long_description": {
         "$concat": [
@@ -62,8 +62,8 @@
         "separator": "\n"
     },
     "long_description_content_type": "text/markdown",
-    "name": "measure-noise",
+    "name": "moz-measure-noise",
     "packages": ["measure_noise"],
     "url": "https://github.com/mozilla/measure-noise",
-    "version": "2.58.19240"
+    "version": "2.59.0.1"
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 

--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 

--- a/tests/test_perf_alert.py
+++ b/tests/test_perf_alert.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contact: Kyle Lahnakoski (kyle@lahnakoski.com)
+# Contact: Perftest Team (perftest@mozilla.com)
 #
 from __future__ import absolute_import, division, unicode_literals
 


### PR DESCRIPTION
This patch updates the contact info of the project to `perftest@mozilla.com` and the package name to `moz-measure-noise`.